### PR TITLE
[BOP-1161] Helm Chart for Dex HTTP Server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.23.1-alpine3.20 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ARG LDFLAGS
 
 WORKDIR /app
 
@@ -17,7 +18,7 @@ COPY . /app
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o dex-http-server cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags="${LDFLAGS}" -a -o dex-http-server cmd/main.go
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /

--- a/charts/dex-http-server/.helmignore
+++ b/charts/dex-http-server/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/dex-http-server/Chart.yaml
+++ b/charts/dex-http-server/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: dex-http-server-chart
+description: A Helm chart for deploying the Dex HTTP server
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v0.5.0"

--- a/charts/dex-http-server/templates/NOTES.txt
+++ b/charts/dex-http-server/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "dex-http-server.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "dex-http-server.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "dex-http-server.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "dex-http-server.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/dex-http-server/templates/_helpers.tpl
+++ b/charts/dex-http-server/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dex-http-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "dex-http-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "dex-http-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "dex-http-server.labels" -}}
+helm.sh/chart: {{ include "dex-http-server.chart" . }}
+{{ include "dex-http-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "dex-http-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "dex-http-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "dex-http-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "dex-http-server.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/dex-http-server/templates/_params.tpl
+++ b/charts/dex-http-server/templates/_params.tpl
@@ -1,0 +1,5 @@
+{{- define "dex-http-server.params" -}}
+{{- if .Values.grpc.server -}}
+- --grpc-server={{.Values.grpc.server | trim }}
+{{- end }}
+{{- end -}}

--- a/charts/dex-http-server/templates/deployment.yaml
+++ b/charts/dex-http-server/templates/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dex-http-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dex-http-server.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "dex-http-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "dex-http-server.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "dex-http-server.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          args:
+            - --http-port=8080
+            - --grpc-certs-path=/etc/dex-grpc-certs
+            {{- include "dex-http-server.params" . | nindent 12 }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/dex-http-server/templates/ingress.yaml
+++ b/charts/dex-http-server/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "dex-http-server.fullname" . }}
+  labels:
+    {{- include "dex-http-server.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "dex-http-server.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/dex-http-server/templates/rbac.yaml
+++ b/charts/dex-http-server/templates/rbac.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "dex-http-server.fullname" . }}
+  labels:
+    {{- include "dex-http-server.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [ "rbac.authorization.k8s.io" ]
+    resources: ["clusterrolebindings"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "dex-http-server.fullname" . }}-cluster
+  labels:
+    {{- include "dex-http-server.labels" . | nindent 4 }}
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: {{ include "dex-http-server.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+    name: {{ include "dex-http-server.serviceAccountName" . }}
+{{- end }}

--- a/charts/dex-http-server/templates/service.yaml
+++ b/charts/dex-http-server/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dex-http-server.fullname" . }}
+  labels:
+    {{- include "dex-http-server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "dex-http-server.selectorLabels" . | nindent 4 }}

--- a/charts/dex-http-server/templates/serviceaccount.yaml
+++ b/charts/dex-http-server/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dex-http-server.serviceAccountName" . }}
+  labels:
+    {{- include "dex-http-server.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/dex-http-server/values.yaml
+++ b/charts/dex-http-server/values.yaml
@@ -1,0 +1,94 @@
+# Default values for dex-http-server.
+
+
+# Default values for dex-http-server.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+image:
+  repository: ghcr.io/mirantiscontainers/dex-http-server
+  pullPolicy: IfNotPresent
+  tag: "v0.5.0"
+
+grpc:
+  server: dex:5557
+
+# This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: "dex-http-server"
+fullnameOverride: "dex-http-server"
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+rbac:
+  create: true
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+# fsGroup: 2000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  seccompProfile:
+   type: RuntimeDefault
+  capabilities:
+    drop:
+     - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+  hosts:
+    - paths:
+        - path: /api/dex(/|$)(.*)
+          pathType: ImplementationSpecific
+  tls:
+    - secretName: auth-https.tls
+      hosts:
+        - example.com
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+#   memory: 128Mi
+
+volumes:
+  - name: dex-grpc-certs
+    secret:
+      secretName: auth-grpc.tls
+volumeMounts:
+  - name: dex-grpc-certs
+    mountPath: /etc/dex-grpc-certs
+    readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+

--- a/deploy/static/dex-http-server.yaml
+++ b/deploy/static/dex-http-server.yaml
@@ -35,7 +35,9 @@ metadata:
 spec:
   ports:
     - port: 80
-      targetPort: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
   selector:
     app: dex-http-server
 ---
@@ -57,10 +59,10 @@ spec:
                 port:
                   number: 80
             path: /api/dex(/|$)(.*)
-            pathType: Prefix
+            pathType: ImplementationSpecific
   tls:
     - hosts:
-        - example.com
+        - l63pjn-mke4-lb-27f36ee8e351c0a1.elb.us-west-1.amazonaws.com
       secretName: auth-https.tls
 ---
 apiVersion: apps/v1
@@ -89,7 +91,9 @@ spec:
             - --grpc-certs-path=/etc/dex-grpc-certs
           imagePullPolicy: Always
           ports:
-            - containerPort: 8080
+            - name: http
+              containerPort: 8080
+              protocol: TCP
           volumeMounts:
             - name: dex-grpc-certs
               mountPath: /etc/dex-grpc-certs
@@ -106,23 +110,3 @@ spec:
         - name: dex-grpc-certs
           secret:
             secretName: auth-grpc.tls
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: shell-demo
-  namespace: mke
-spec:
-  volumes:
-    - name: dex-grpc-certs
-      secret:
-        secretName: auth-grpc.tls
-  containers:
-    - name: nginx
-      image: nginx
-      volumeMounts:
-        - name: dex-grpc-certs
-          mountPath: /etc/dex-grpc-certs
-          readOnly: true
-  hostNetwork: true
-  dnsPolicy: Default


### PR DESCRIPTION
## Summary

The PR has following changes:
1. Adds helm chart for the dex-http-server
2. Fixes ldflags to pass version, date etc to the build

## Description

Adding the helm chart for **dex http server**

Here is the default output of the helm chat with `helm template` command:
```
---
# Source: dex-http-server-chart/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: dex-http-server
  labels:
    helm.sh/chart: dex-http-server-chart-0.1.0
    app.kubernetes.io/name: dex-http-server
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.5.0"
    app.kubernetes.io/managed-by: Helm
---
# Source: dex-http-server-chart/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: dex-http-server
  labels:
    helm.sh/chart: dex-http-server-chart-0.1.0
    app.kubernetes.io/name: dex-http-server
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.5.0"
    app.kubernetes.io/managed-by: Helm
rules:
  - apiGroups: [ "rbac.authorization.k8s.io" ]
    resources: ["clusterrolebindings"]
    verbs: ["get", "list"]
---
# Source: dex-http-server-chart/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: dex-http-server-cluster
  labels:
    helm.sh/chart: dex-http-server-chart-0.1.0
    app.kubernetes.io/name: dex-http-server
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.5.0"
    app.kubernetes.io/managed-by: Helm
roleRef:
  kind: ClusterRole
  apiGroup: rbac.authorization.k8s.io
  name: dex-http-server
subjects:
  - kind: ServiceAccount
    namespace: default
    name: dex-http-server
---
# Source: dex-http-server-chart/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: dex-http-server
  labels:
    helm.sh/chart: dex-http-server-chart-0.1.0
    app.kubernetes.io/name: dex-http-server
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.5.0"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
    - port: 80
      targetPort: http
      protocol: TCP
      name: http
  selector:
    app.kubernetes.io/name: dex-http-server
    app.kubernetes.io/instance: release-name
---
# Source: dex-http-server-chart/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dex-http-server
  namespace: default
  labels:
    helm.sh/chart: dex-http-server-chart-0.1.0
    app.kubernetes.io/name: dex-http-server
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.5.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: dex-http-server
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      labels:
        helm.sh/chart: dex-http-server-chart-0.1.0
        app.kubernetes.io/name: dex-http-server
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "v0.5.0"
        app.kubernetes.io/managed-by: Helm
    spec:
      serviceAccountName: dex-http-server
      securityContext:
        {}
      containers:
        - name: dex-http-server-chart
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 1000
            seccompProfile:
              type: RuntimeDefault
          image: "ghcr.io/mirantiscontainers/dex-http-server:v0.5.0"
          args:
            - --http-port=8080
            - --grpc-certs-path=/etc/dex-grpc-certs
            - --grpc-server=dex:5557
          imagePullPolicy: IfNotPresent
          ports:
            - name: http
              containerPort: 8080
              protocol: TCP
          resources:
            {}
          volumeMounts:
            - mountPath: /etc/dex-grpc-certs
              name: dex-grpc-certs
              readOnly: true
      volumes:
        - name: dex-grpc-certs
          secret:
            secretName: auth-grpc.tls
---
# Source: dex-http-server-chart/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: dex-http-server
  labels:
    helm.sh/chart: dex-http-server-chart-0.1.0
    app.kubernetes.io/name: dex-http-server
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.5.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
    nginx.ingress.kubernetes.io/rewrite-target: /$2
spec:
  tls:
    - hosts:
        - "example.com"
      secretName: auth-https.tls
  rules:
    - host:
      http:
        paths:
          - path: /api/dex(/|$)(.*)
            pathType: ImplementationSpecific
            backend:
              service:
                name: dex-http-server
                port:
                  number: 80
```

## Testing

The helm chat has been manually push to `ghcr.io/mirantiscontainers/dex-http-server-chart:0.1.0`.
To test with MKE4, add the following addon in MKE4 config:
```
  addons:
    - name: dex-http-server
      kind: chart
      enabled: true
      namespace: mke
      chart:
        name: dex-http-server-chart
        version: 0.1.0
        repo: oci://ghcr.io/mirantiscontainers
        values: |-
          grpc:
            server: authentication-dex:5557
          ingress:
            tls:
              - hosts:
                  - l63pjn-mke4-lb-27f36ee8e351c0a1.elb.us-west-1.amazonaws.com
                secretName: auth-https.tls
```

The helm chart install successfully and API can be reached:
```
curl -k --location 'https://l63pjn-mke4-lb-27f36ee8e351c0a1.elb.us-west-1.amazonaws.com/api/dex/v1/users/verify' \
--header 'Accept: application/json' \
--header 'Authorization: Bearer  ***'
```
```
[{"email":"admin", "hash":"", "username":"admin", "userId":"1940d2cf-518b-4932-bd0f-44f8a02a1f97"},{"email":"ranyodh10@gmail.com", "hash":"", "username":"ranyodh5", "userId":"0f9451a0-819a-4911-82f6-22a1e52a6206"},{"email":"ranyodh1@gmail.com", "hash":"", "username":"ranyodh1", "userId":"ebd40c10-1b29-4e19-8915-1e4e949cff3c"},{"email":"ranyodh2@gmail.com", "hash":"", "username":"ranyodh2", "userId":"ebd40c10-1b29-4e19-8915-1e4e949cff3c"},{"email":"ranyodh3@gmail.com", "hash":"", "username":"ranyodh3", "userId":"ebd40c10-1b29-4e19-8915-1e4e949cff3d"},{"email":"ranyodh5@gmail.com", "hash":"", "username":"ranyodh5", "userId":"03bd3fe0-af0d-4d35-af53-cf1627a44e71"},{"email":"ranyodh@gmail.com", "hash":"", "username":"ranyodh", "userId":"ebd40c10-1b29-4e19-8915-1e4e949cff3d"}]
```