### PR TITLE
Fix issue where request does not parse correct json key (new_hash vs newHash, new_username vs newUsername)

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -18,5 +18,6 @@ plugins:
       - output_format=yaml
       - generate_unbound_methods=false
       - grpc_api_configuration=api/mapping.yaml
+      - openapi_configuration=api/swagger.yaml
 inputs:
   - directory: api/

--- a/gen/openapiv2/api/api.swagger.yaml
+++ b/gen/openapiv2/api/api.swagger.yaml
@@ -1,9 +1,12 @@
 swagger: "2.0"
 info:
-  title: api.proto
-  version: version not set
+  title: Dex HTTP API
+  version: "1.0"
 tags:
   - name: Dex
+    description: Dex HTTP API to manage users
+schemes:
+  - https
 consumes:
   - application/json
 produces:
@@ -21,6 +24,12 @@ paths:
             items:
               type: object
               $ref: '#/definitions/apiPassword'
+        "401":
+          description: Returned when the user does not provide authentication using Bearer token.
+          schema: {}
+        "403":
+          description: Returned when the user does not have permission to access the resource.
+          schema: {}
         default:
           description: An unexpected error response.
           schema:
@@ -35,6 +44,12 @@ paths:
           description: A successful response.
           schema:
             $ref: '#/definitions/apiCreatePasswordResp'
+        "401":
+          description: Returned when the user does not provide authentication using Bearer token.
+          schema: {}
+        "403":
+          description: Returned when the user does not have permission to access the resource.
+          schema: {}
         default:
           description: An unexpected error response.
           schema:
@@ -56,6 +71,12 @@ paths:
           description: A successful response.
           schema:
             $ref: '#/definitions/apiVerifyPasswordResp'
+        "401":
+          description: Returned when the user does not provide authentication using Bearer token.
+          schema: {}
+        "403":
+          description: Returned when the user does not have permission to access the resource.
+          schema: {}
         default:
           description: An unexpected error response.
           schema:
@@ -77,6 +98,12 @@ paths:
           description: A successful response.
           schema:
             $ref: '#/definitions/apiDeletePasswordResp'
+        "401":
+          description: Returned when the user does not provide authentication using Bearer token.
+          schema: {}
+        "403":
+          description: Returned when the user does not have permission to access the resource.
+          schema: {}
         default:
           description: An unexpected error response.
           schema:
@@ -96,6 +123,12 @@ paths:
           description: A successful response.
           schema:
             $ref: '#/definitions/apiUpdatePasswordResp'
+        "401":
+          description: Returned when the user does not provide authentication using Bearer token.
+          schema: {}
+        "403":
+          description: Returned when the user does not have permission to access the resource.
+          schema: {}
         default:
           description: An unexpected error response.
           schema:
@@ -283,3 +316,10 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/protobufAny'
+securityDefinitions:
+  ApiKeyAuth:
+    type: apiKey
+    name: Authorization
+    in: header
+security:
+  - ApiKeyAuth: []

--- a/internal/middlewares/users_test.go
+++ b/internal/middlewares/users_test.go
@@ -1,11 +1,112 @@
 package middlewares
 
 import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/bcrypt"
+
+	"github.com/mirantiscontainers/dex-http-server/gen/go/api"
 )
+
+var mockedRequestPatternGetter = func(patternToReturn string) func(r *http.Request) (string, error) {
+	return func(r *http.Request) (string, error) {
+		return patternToReturn, nil
+	}
+}
+
+func Test_createUserMiddleware(t *testing.T) {
+	// Mock mockNext handler
+
+	requestPatternGetter = mockedRequestPatternGetter("/v1/users")
+
+	plainTextPassword := "mysecretpassword"
+	mockNext := func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+		// Decode the modified request body
+		var req api.CreatePasswordReq
+		err := marshaler.NewDecoder(r.Body).Decode(&req.Password)
+		assert.NoError(t, err)
+
+		// Check if the password was correctly encrypted
+		err = bcrypt.CompareHashAndPassword(req.Password.Hash, []byte(plainTextPassword))
+		assert.NoError(t, err, "password was not encrypted")
+
+		// Check if the UUID is generated
+		_, err = uuid.Parse(req.Password.UserId)
+		assert.NoError(t, err, "userId is not a valid UUID")
+	}
+
+	// Create a sample request payload
+	body := fmt.Sprintf(`
+	{
+		"hash": "%s",
+		"userId": "someuuid"
+	}
+	`, base64.StdEncoding.EncodeToString([]byte(plainTextPassword)))
+
+	// Create a new HTTP request
+	req := httptest.NewRequest(http.MethodPost, "/v1/users/email/ranyodh", bytes.NewReader([]byte(body)))
+
+	// Create a response recorder
+	rr := httptest.NewRecorder()
+
+	// Call the middleware
+	handler := createUserMiddleware(mockNext)
+	handler(rr, req, nil)
+
+	// Check the response status code
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func Test_updateUserMiddleware(t *testing.T) {
+
+	requestPatternGetter = mockedRequestPatternGetter("/users/{email=*}")
+
+	newPlainTextPassword := "mysecretpassword"
+	newUsername := "mysecretpassword"
+	mockNext := func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+		// Decode the modified request body
+		var req api.UpdatePasswordReq
+		err := marshaler.NewDecoder(r.Body).Decode(&req)
+		assert.NoError(t, err)
+
+		// Check if the new password is encrypted
+		err = bcrypt.CompareHashAndPassword(req.NewHash, []byte(newPlainTextPassword))
+		assert.NoError(t, err)
+
+		// Check if the new username is correct
+		assert.Equal(t, newUsername, req.NewUsername)
+	}
+
+	reqBodyStr := fmt.Sprintf(`
+	{
+		"newHash": "%s",
+		"newUsername": "%s"
+	}
+`, base64.StdEncoding.EncodeToString([]byte(newPlainTextPassword)), newUsername)
+
+	// Create a new HTTP request
+	req := httptest.NewRequest(http.MethodPut, "/users/{email=*}", bytes.NewReader([]byte(reqBodyStr)))
+	req = req.WithContext(runtime.NewServerMetadataContext(req.Context(), runtime.ServerMetadata{}))
+
+	// Create a response recorder
+	rr := httptest.NewRecorder()
+
+	// Call the middleware
+	handler := updateUserMiddleware(mockNext)
+	handler(rr, req, map[string]string{})
+
+	// Check the response status code
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
 
 func Test_isCreateUserRequest(t *testing.T) {
 
@@ -55,12 +156,18 @@ func Test_isUpdateUserRequest(t *testing.T) {
 
 func Test_encryptPassword(t *testing.T) {
 	password := []byte("mysecretpassword")
-	encrypted, err := encryptPassword(password)
+	encrypted, err := encryptPasswordHash(password)
 	if err != nil {
-		t.Fatalf("encryptPassword() error = %v", err)
+		t.Fatalf("encryptPasswordHash() error = %v", err)
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(encrypted), password); err != nil {
 		t.Errorf("bcrypt.CompareHashAndPassword() error = %v", err)
 	}
+}
+
+type httpPatternKey struct{}
+
+func withHTTPPattern(ctx context.Context, httpPattern runtime.Pattern) context.Context {
+	return context.WithValue(ctx, httpPatternKey{}, httpPattern)
 }

--- a/internal/middlewares/users_test.go
+++ b/internal/middlewares/users_test.go
@@ -2,7 +2,6 @@ package middlewares
 
 import (
 	"bytes"
-	"context"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -164,10 +163,4 @@ func Test_encryptPassword(t *testing.T) {
 	if err := bcrypt.CompareHashAndPassword([]byte(encrypted), password); err != nil {
 		t.Errorf("bcrypt.CompareHashAndPassword() error = %v", err)
 	}
-}
-
-type httpPatternKey struct{}
-
-func withHTTPPattern(ctx context.Context, httpPattern runtime.Pattern) context.Context {
-	return context.WithValue(ctx, httpPatternKey{}, httpPattern)
 }


### PR DESCRIPTION
### Summary

The PR has two changes:
1. Fix json key name issue
2. Updates swagger specs (not related to changes in this PR)

### Description

This PR includes fix for an issue where the following request fails to update username:

```
curl -X PUT ${baseUrl}/api/dex/v1/users/someuser@email.com
{
    "newUsername": "someuser2"
}'
```

But the following worked:
```
curl -X PUT ${baseUrl}/api/dex/v1/users/someuser@email.com
{
    "new_username": "someuser2"
}'
```
The issue was caused by the middleware using the default json marshaller (from "encoding/json"). With the proto generated code, the `runtime.HTTPBodyMarshaler` (https://pkg.go.dev/github.com/grpc-ecosystem/grpc-gateway/v2/runtime#HTTPBodyMarshaler) is a better choice as it correctly marshals the fields.

### Testing

I have added unit tests for the middleware that caused the issue. Also tested manually by deploying the custom image
